### PR TITLE
CASMPET-7447: Pin cray-vpa tests image to bitnami/kubectl:1.32

### DIFF
--- a/kubernetes/cray-vpa/Chart.yaml
+++ b/kubernetes/cray-vpa/Chart.yaml
@@ -25,7 +25,7 @@ apiVersion: v2
 appVersion: "4.7.2"
 description: "HPE Vertical Pod Autoscaler (VPA) Helm Chart"
 name: cray-vpa
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: vpa
     version: 4.7.2

--- a/kubernetes/cray-vpa/values.yaml
+++ b/kubernetes/cray-vpa/values.yaml
@@ -48,3 +48,7 @@ vpa:
     image:
       repository: "artifactory.algol60.net/csm-docker/stable/registry.k8s.io/autoscaling/vpa-updater"
       tag: 1.3.0
+  tests:
+    image:
+      repository: "artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl"
+      tag: 1.32


### PR DESCRIPTION
## Summary and Scope

The `vpa` chart from Fairwinds contains a `tests` component that was pulling the latest `kubectl` from  `docker.io/library/bitnami`.  The version keeps changing causing CSM build failures.  Pin the `tests` image to a specific image in Artifactory.
 
## Issues and Related PRs

* Resolves [CASMPET-7447](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7447)

## Testing
Will do a CSM build with new version once merged.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

