### PR TITLE
CASMPET-7447: Tests image needs to be in quotes otherwise seen as float

### DIFF
--- a/kubernetes/cray-vpa/Chart.yaml
+++ b/kubernetes/cray-vpa/Chart.yaml
@@ -25,7 +25,7 @@ apiVersion: v2
 appVersion: "4.7.2"
 description: "HPE Vertical Pod Autoscaler (VPA) Helm Chart"
 name: cray-vpa
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: vpa
     version: 4.7.2

--- a/kubernetes/cray-vpa/Chart.yaml
+++ b/kubernetes/cray-vpa/Chart.yaml
@@ -25,7 +25,7 @@ apiVersion: v2
 appVersion: "4.7.2"
 description: "HPE Vertical Pod Autoscaler (VPA) Helm Chart"
 name: cray-vpa
-version: 1.0.1
+version: 1.0.2
 dependencies:
   - name: vpa
     version: 4.7.2

--- a/kubernetes/cray-vpa/values.yaml
+++ b/kubernetes/cray-vpa/values.yaml
@@ -51,4 +51,4 @@ vpa:
   tests:
     image:
       repository: "artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl"
-      tag: 1.32
+      tag: "1.32"

--- a/kubernetes/cray-vpa/values.yaml
+++ b/kubernetes/cray-vpa/values.yaml
@@ -48,3 +48,7 @@ vpa:
     image:
       repository: "artifactory.algol60.net/csm-docker/stable/registry.k8s.io/autoscaling/vpa-updater"
       tag: 1.3.0
+  tests:
+    image:
+      repository: "artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl"
+      tag: 1.32


### PR DESCRIPTION
## Summary and Scope

CSM bulid fails (again) because tests image tag 1.32 seen as a float and not a string.  Use "1.32" as tag.

## Issues and Related PRs

* Resolves [CASMPET-7447](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7447)

## Testing
If CSM build succeeds, we're good.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

