### PR TITLE
CASMPET-7547: Use docker-kubectl 1.32.2 image for tests container

### DIFF
--- a/kubernetes/cray-vpa/Chart.yaml
+++ b/kubernetes/cray-vpa/Chart.yaml
@@ -25,7 +25,7 @@ apiVersion: v2
 appVersion: "4.7.2"
 description: "HPE Vertical Pod Autoscaler (VPA) Helm Chart"
 name: cray-vpa
-version: 1.0.2
+version: 1.0.3
 dependencies:
   - name: vpa
     version: 4.7.2

--- a/kubernetes/cray-vpa/values.yaml
+++ b/kubernetes/cray-vpa/values.yaml
@@ -50,5 +50,5 @@ vpa:
       tag: 1.3.0
   tests:
     image:
-      repository: "artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl"
-      tag: "1.32"
+      repository: "artifactory.algol60.net/csm-docker/stable/docker-kubectl"
+      tag: 1.32.2


### PR DESCRIPTION
## Summary and Scope
The `cray-vpa` tests container currently uses the `docker.io/library/bitnami/kubectl:1.32` image which contains a number of CVEs.  Modify the tests container to use the clean `docker-kubectl` 1.32.2 image.
## Issues and Related PRs
* Resolves [CASMPET-7547](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7547)

## Testing
Installed unstable chart with `docker-kubectl` image on `beau` successfully. 
```
pit:~/studenym # helm upgrade -n services cray-vpa cray-vpa-1.0.3-20250814135404+d815650.tgz
Release "cray-vpa" has been upgraded. Happy Helming!
NAME: cray-vpa
LAST DEPLOYED: Thu Aug 14 14:25:41 2025
NAMESPACE: services
STATUS: deployed
REVISION: 2
pit:~/studenym #

  test:
    Container ID:  containerd://7361e398b0f3deadda64faecc0c6d87f00977260e347336be5510b95d06967ec
    Image:         registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
    Image ID:      artifactory.algol60.net/csm-docker/stable/docker-kubectl@sha256:59d4b238a81529c2118678796f7c032b0c7d538f30f52d8f9fab4440e7db5295
    Port:          <none>
    Host Port:     <none>
    Command:
      kubectl
    Args:
      get
      crd
      verticalpodautoscalercheckpoints.autoscaling.k8s.io
      verticalpodautoscalers.autoscaling.k8s.io
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Thu, 14 Aug 2025 14:26:51 +0000
      Finished:     Thu, 14 Aug 2025 14:26:51 +0000
    Ready:          False
    Restart Count:  0
    Limits:
      cpu:     2
      memory:  2Gi
    Requests:
      cpu:        10m
      memory:     64Mi
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-xxwnl (ro)

pit:~ # kubectl logs -n services cray-vpa-test-crds-available
NAME                                                  CREATED AT
verticalpodautoscalercheckpoints.autoscaling.k8s.io   2025-08-11T15:13:24Z
verticalpodautoscalers.autoscaling.k8s.io             2025-08-11T15:13:24Z
```

## Risks and Mitigations

No risk.  The tests are not executed and the image change does not affect the service.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

